### PR TITLE
Fixed Ritual Summon Roll validation logic

### DIFF
--- a/DungeonDiceMonsters/Board Elements/RollDiceMenu.cs
+++ b/DungeonDiceMonsters/Board Elements/RollDiceMenu.cs
@@ -444,38 +444,21 @@ namespace DungeonDiceMonsters
                         else
                         {
                             //This is a Ritual Monster, validate the Ritual Summon can be completed.
-                            bool dice2isRitualMatch = false;
-                            bool dice3isRitualMatch = false;
-                            if ((DiceXCrest == Crest.RITU && DiceXValue == DiceZValue))
+                            if (DiceXCrest == Crest.RITU && (DiceZ.RitualCard == DiceX.Name))
                             {
-                                dice2isRitualMatch = true;
+                                //Set result as "Ritual Summon"
+                                return 4;
                             }
-                            if ((DiceYCrest == Crest.RITU && DiceYValue == DiceZValue))
+                            else if (DiceYCrest == Crest.RITU && (DiceZ.RitualCard == DiceY.Name))
                             {
-                                dice3isRitualMatch = true;
-                            }
-
-                            //If Any of the other 2 dices are also ritual with the same value
-                            if (dice2isRitualMatch || dice3isRitualMatch)
-                            {
-                                //then check if the ritual card is the designated ritual for this monster
-                                if (DiceX.RitualCard == DiceY.Name)
-                                {
-                                    //Set result as "Ritual Summon"
-                                    return 4;
-                                }
-                                else
-                                {
-                                    //Set result as "Star/Ritual No Match"
-                                    return 3;
-                                }
+                                //Set result as "Ritual Summon"
+                                return 4;
                             }
                             else
                             {
                                 //Set result as "Star/Ritual No Match"
                                 return 3;
                             }
-
                         }
                     }
                     else
@@ -1469,11 +1452,5 @@ namespace DungeonDiceMonsters
             }));
         }
         #endregion
-
-        /*
-            Invoke(new MethodInvoker(delegate () {
-                
-            }));
-        */
     }
 }

--- a/DungeonDiceMonsters/bin/Debug/DB/CardListDB.json
+++ b/DungeonDiceMonsters/bin/Debug/DB/CardListDB.json
@@ -1648,7 +1648,7 @@
   },
   {
     "id": "43694075",
-    "name": "Novox's Prayer",
+    "name": "Novox’s Prayer",
     "category": "Spell",
     "type": "Ritual",
     "sectype": "NONE",


### PR DESCRIPTION
I cleaned up the Logic to validate if a Ritual MONSTER can be Ritual Summon.