### PR TITLE
PvPServer: Server now handles when a player disconnects in the middle of the match

### DIFF
--- a/DDMPvPServer/Match.cs
+++ b/DDMPvPServer/Match.cs
@@ -113,7 +113,6 @@ namespace DDMPvPServer
             }
             return output;
         }
-
         public void RemovePlayerInWaiting()
         {
             AddLogMessage("RED Player disconnected: Removing it from the match! - RED Spot available again.");
@@ -126,6 +125,15 @@ namespace DDMPvPServer
             REDPlayerReady = false;
             BLUEPlayerReady = false;
         }   
+        public void CloseMatch()
+        {
+            MatchClosed = true;
+            AddLogMessage("Match is now closed!!!");
+        }
+        public bool IsClosed()
+        {
+            return MatchClosed;
+        }
 
         private int MatchID;
         private int REDPlayerID = -1;
@@ -136,6 +144,7 @@ namespace DDMPvPServer
         private string BLUEPlayerDeckData = "NO SET";
         private bool REDPlayerReady = false;
         private bool BLUEPlayerReady = false;
+        private bool MatchClosed = false;
         private List<string> LogTrace = new List<string>();
 
     }

--- a/DDMPvPServer/obj/Debug/net8.0-windows/DDMPvPServer.AssemblyInfo.cs
+++ b/DDMPvPServer/obj/Debug/net8.0-windows/DDMPvPServer.AssemblyInfo.cs
@@ -14,7 +14,7 @@ using System.Reflection;
 [assembly: System.Reflection.AssemblyCompanyAttribute("DDMPvPServer")]
 [assembly: System.Reflection.AssemblyConfigurationAttribute("Debug")]
 [assembly: System.Reflection.AssemblyFileVersionAttribute("1.0.0.0")]
-[assembly: System.Reflection.AssemblyInformationalVersionAttribute("1.0.0+6b999e36ec2539249e39c578fea82768a8b7c064")]
+[assembly: System.Reflection.AssemblyInformationalVersionAttribute("1.0.0+c390cf43b4b5936b8b8cb8b28a8acd0c2aefe2da")]
 [assembly: System.Reflection.AssemblyProductAttribute("DDMPvPServer")]
 [assembly: System.Reflection.AssemblyTitleAttribute("DDMPvPServer")]
 [assembly: System.Reflection.AssemblyVersionAttribute("1.0.0.0")]


### PR DESCRIPTION
During an active match, if one of the players disconnects, the server will notify the other player and that player will be kicked out to the PvPMenu with a message stating that the other player disconnected. At this point that active player can resume their actions in the PvPMenu.