### PR TITLE
Game Over sequence disconnects from server automatically

### DIFF
--- a/DDMPvPServer/Server.cs
+++ b/DDMPvPServer/Server.cs
@@ -138,6 +138,15 @@ namespace DDMPvPServer
                             }
                             break;
 
+                        case "[GAME OVER]":
+                            staticServerObject.UpdateConnectionLog(string.Format("X Client ID: {0} disconnected during the Game Over!", id));
+                            ActiveMatch.AddLogMessage(string.Format("X Player [{0}] disconnected during the game over. Match will be closed.", ClientPlayerColor));
+                            ActiveMatch.CloseMatch();
+                            //Just forward this back to the same clieent so the thread can end the connection
+                            //from the client side.
+                            SendMessage("[GAME OVER]", client);
+                            break;
+
                         //All other messages will simply forward the messages to the opponent client
                         default:
                             int OpponentClientID = ActiveMatch.GetOpponentClientID(ClientPlayerColor);

--- a/DungeonDiceMonsters/BoardPvP.Designer.cs
+++ b/DungeonDiceMonsters/BoardPvP.Designer.cs
@@ -1783,6 +1783,7 @@
             this.btnExit.Text = "Exit";
             this.btnExit.UseVisualStyleBackColor = true;
             this.btnExit.Visible = false;
+            this.btnExit.Click += new System.EventHandler(this.btnExit_Click);
             // 
             // label1
             // 

--- a/DungeonDiceMonsters/BoardPvP.cs
+++ b/DungeonDiceMonsters/BoardPvP.cs
@@ -15,10 +15,11 @@ namespace DungeonDiceMonsters
     public partial class BoardPvP : Form
     {
         #region Constructors
-        public BoardPvP(PlayerData Red, PlayerData Blue, PlayerColor UserColor, NetworkStream tmpns)
+        public BoardPvP(PlayerData Red, PlayerData Blue, PlayerColor UserColor, NetworkStream tmpns, PvPMenu pvpmenu)
         {
             //Save a reference to the NetworkStream of our active client connection to send messages to the server
             ns = tmpns;
+            _PvPMenuRef = pvpmenu;
 
             //Initialize Music
             SoundServer.PlayBackgroundMusic(Song.FreeDuel, true);
@@ -175,10 +176,11 @@ namespace DungeonDiceMonsters
             ActivateEffect(BluesymbolEffect);
             _ActiveEffects.Add(BluesymbolEffect);
         }
-        public BoardPvP(PlayerData Red, PlayerData Blue, PlayerColor UserColor, NetworkStream tmpns, bool testing)
+        public BoardPvP(PlayerData Red, PlayerData Blue, PlayerColor UserColor, NetworkStream tmpns, PvPMenu pvpmenu, bool testing)
         {
             //Save a reference to the NetworkStream of our active client connection to send messages to the server
             ns = tmpns;
+            _PvPMenuRef = pvpmenu;
 
             //Initialize Music
             SoundServer.PlayBackgroundMusic(Song.FreeDuel, true);
@@ -1252,12 +1254,7 @@ namespace DungeonDiceMonsters
 
                             if (DefenderSymbol.LP == 0)
                             {
-                                //TODO: defender player loses the game
-                                SoundServer.PlayBackgroundMusic(Song.YouWin, true);
-                                PanelBattleMenu.Visible = false;
-                                PanelEndGameResults.Visible = true;
-                                WaitNSeconds(5000);
-                                btnExit.Visible = true;
+                                StartGameOver();
                             }
                             else
                             {
@@ -1363,12 +1360,7 @@ namespace DungeonDiceMonsters
 
                             if (DefenderSymbol.LP == 0)
                             {
-                                //TODO: defender player loses the game
-                                SoundServer.PlayBackgroundMusic(Song.YouWin, true);
-                                PanelBattleMenu.Visible = false;
-                                PanelEndGameResults.Visible = true;
-                                WaitNSeconds(5000);
-                                btnExit.Visible = true;
+                                StartGameOver();
                             }
                             else
                             {
@@ -1521,6 +1513,19 @@ namespace DungeonDiceMonsters
                 lblActionInstruction.Visible = true;
             }
         }
+        private void StartGameOver()
+        {
+            //TODO: defender player loses the game
+            SoundServer.PlayBackgroundMusic(Song.YouWin, true);
+            PanelBattleMenu.Visible = false;
+            PanelEndGameResults.Visible = true;
+
+            //Send the server the gameover message
+            SendMessageToServer("[GAME OVER]");
+
+            WaitNSeconds(5000);
+            btnExit.Visible = true;
+        }
         #endregion
 
         #region Event Listeners
@@ -1536,6 +1541,10 @@ namespace DungeonDiceMonsters
             {
                 Environment.Exit(Environment.ExitCode);
             }           
+        }
+        private void btnExit_Click(object sender, EventArgs e)
+        {
+            _PvPMenuRef.ReturnToPvPMenuFromGameOverBoard();
         }
         #endregion
 
@@ -2816,6 +2825,7 @@ namespace DungeonDiceMonsters
         private List<string> _EffectsLog = new List<string>();
         private List<Effect> _ActiveEffects = new List<Effect>();
         private bool _AppShutDownWhenClose = true;
+        private PvPMenu _PvPMenuRef;
         #endregion
 
         #region Effect Activation Methods

--- a/DungeonDiceMonsters/Forms/PvPMenu.cs
+++ b/DungeonDiceMonsters/Forms/PvPMenu.cs
@@ -167,6 +167,7 @@ namespace DungeonDiceMonsters
                     //Close the BoardPVP form (this will also close the RollDiceMenu if it was open as well)
                     Invoke(new MethodInvoker(delegate ()
                     {
+                        SoundServer.PlayBackgroundMusic(Song.MainMenu, true);
                         _CurrentBoardPVP.CloseWithoutShuttingDownTheApp();
                         lblWaitMessage.Text = "Opponent disconnected, Match ENDED.";
                         lblBluePlayerName.Visible = false;
@@ -182,6 +183,7 @@ namespace DungeonDiceMonsters
                     //Close the BoardPVP form (this will also close the RollDiceMenu if it was open as well)
                     Invoke(new MethodInvoker(delegate ()
                     {
+                        SoundServer.PlayBackgroundMusic(Song.MainMenu, true);
                         if (_CurrentBoardPVP != null) { _CurrentBoardPVP.CloseWithoutShuttingDownTheApp(); }
                         Enabled = true;
                         lblWaitMessage.Text = "Server was shutdown, Match ENDED.";
@@ -194,11 +196,28 @@ namespace DungeonDiceMonsters
                         Show();
                     }));
                     break;
+                case "[GAME OVER]":
+                    //Dont do anything, all we need is the client/server connection to be break
+                    //which should be done by now.
+                    break;
                 default:
                     //ANY OTHER MESSAGE WILL BE FORWARDED TO THE BoardPVP
                     _CurrentBoardPVP.ReceiveMesageFromServer(DATARECEIVED);
                     break;
             }
+        }
+        public void ReturnToPvPMenuFromGameOverBoard()
+        {
+            SoundServer.PlayBackgroundMusic(Song.MainMenu, true);
+            _CurrentBoardPVP.CloseWithoutShuttingDownTheApp();
+            Enabled = true;
+            lblBluePlayerName.Visible = false;
+            lblRedPlayerName.Visible = false;
+            PanelDeckSelection.Visible = true;
+            lblWaitMessage.Visible = false;
+            btnExit.Visible = true;
+            btnFindMatch.Visible = true;
+            Show();
         }
         #endregion
 
@@ -214,8 +233,8 @@ namespace DungeonDiceMonsters
 
             if (MyColor == PlayerColor.RED)
             {
-                _CurrentBoardPVP = new BoardPvP(user, opponent, MyColor, ns);
-                //_CurrentBoardPVP = new BoardPvP(user, opponent, MyColor, ns, true);
+                _CurrentBoardPVP = new BoardPvP(user, opponent, MyColor, ns, this);
+                //_CurrentBoardPVP = new BoardPvP(user, opponent, MyColor, ns, this, true);
                 Hide();
                 Enabled = true;
                 PanelDeckSelection.Visible = true;
@@ -226,8 +245,8 @@ namespace DungeonDiceMonsters
             }
             else
             {
-                _CurrentBoardPVP = new BoardPvP(opponent, user, MyColor, ns);
-                //_CurrentBoardPVP = new BoardPvP(opponent, user, MyColor, ns, true);
+                _CurrentBoardPVP = new BoardPvP(opponent, user, MyColor, ns, this);
+                //_CurrentBoardPVP = new BoardPvP(opponent, user, MyColor, ns,this, true);
                 Hide();
                 Enabled = true;
                 PanelDeckSelection.Visible = true;
@@ -256,7 +275,7 @@ namespace DungeonDiceMonsters
                     StaticPvPMenu.MessageReceived(DATARECEIVED);
 
                     //If the Data received was the opponent disconnect notification, end the loop to disconnect client
-                    if (DATARECEIVED == "[OPPONENT DISCONNECT]")
+                    if (DATARECEIVED == "[OPPONENT DISCONNECT]" || DATARECEIVED == "[GAME OVER]")
                     {
                         break;
                     }


### PR DESCRIPTION
When a player wins the match and the game over panel shows up, the PvPBoard Form will send a message to the server to notify the game over. this message will be forwards back to the client to allow the client listening thread to stop and disconnect from the server. Now at this point the player will still be in the PvPBoard but not longer connected to the server. From here all the player has to do is click the "Exit" button to return to the PvPMenu ready to join another match