### PR TITLE
Battle Menu will no longer show the advantage menus during a battle against a non-monster

### DIFF
--- a/DungeonDiceMonsters/BoardPvP.cs
+++ b/DungeonDiceMonsters/BoardPvP.cs
@@ -912,7 +912,7 @@ namespace DungeonDiceMonsters
 
                 //If attacker monster has an advantage, enable the adv subpanel
                 bool AttackerHasAdvantage = HasAttributeAdvantage(Attacker, Defender);
-                if (AttackerHasAdvantage)
+                if (AttackerHasAdvantage && Defender.Category == Category.Monster)
                 {
                     PanelAttackerAdvBonus.Visible = true;
                     //Show the + button at the start                    
@@ -957,7 +957,7 @@ namespace DungeonDiceMonsters
                     }
                     //If defender monster has an advantage, enable the adv subpanel
                     bool DefenderHasAdvantage = HasAttributeAdvantage(Defender, Attacker);
-                    if (DefenderHasAdvantage && DefenderData.Crests_DEF > 0)
+                    if (DefenderHasAdvantage && DefenderData.Crests_DEF > 0 && Defender.Category == Category.Monster)
                     {
                         PanelDefenderAdvBonus.Visible = true;
                         //Show the + button at the start


### PR DESCRIPTION
This will prevent the advantage menu to show up when battling a Symbol or a Spell/Trap