### PR TITLE
Attribute Advantage Panel fix

### DIFF
--- a/DungeonDiceMonsters/BoardPvP.cs
+++ b/DungeonDiceMonsters/BoardPvP.cs
@@ -3341,10 +3341,13 @@ namespace DungeonDiceMonsters
                     bool AttackerHasAdvantage = HasAttributeAdvantage(Attacker, Defender);
                     if (AttackerHasAdvantage && Defender.Category == Category.Monster)
                     {
-                        PanelAttackerAdvBonus.Visible = true;
+                        //Start the bonus crests at default 0
+                        _AttackBonusCrest = 0;
+                        lblAttackerBonusCrest.Text = "0";
                         //Show the + button at the start                    
                         lblAttackerAdvMinus.Visible = false;
                         lblAttackerAdvPlus.Visible = true;
+                        PanelAttackerAdvBonus.Visible = true;
                     }
                     else
                     {
@@ -3386,10 +3389,12 @@ namespace DungeonDiceMonsters
                         bool DefenderHasAdvantage = HasAttributeAdvantage(Defender, Attacker);
                         if (DefenderHasAdvantage && DefenderData.Crests_DEF > 0 && Defender.Category == Category.Monster)
                         {
-                            PanelDefenderAdvBonus.Visible = true;
+                            _DefenseBonusCrest = 0;
+                            lblDefenderBonusCrest.Text = "0";
                             //Show the + button at the start
                             lblDefenderAdvMinus.Visible = false;
                             lblDefenderAdvPlus.Visible = true;
+                            PanelDefenderAdvBonus.Visible = true;
                         }
                         else
                         {


### PR DESCRIPTION
When a player has a Attribute advantage, their battle menu UI will show the Bonus Crests panel. This panel was missing setting up the bonus crests count to the default 0. So if you happen to use bonus crests then the next battle the UI will start with that same amount rather then 0. This has been fixed.