### PR TITLE
"Move Range" implemented

### DIFF
--- a/DungeonDiceMonsters/Board Elements/BoardForm.cs
+++ b/DungeonDiceMonsters/Board Elements/BoardForm.cs
@@ -677,7 +677,7 @@ namespace DungeonDiceMonsters
                     if (!(northTile.IsOccupied))
                     {
                         //Change the Adjencent tile's border to gree to mark that you can move
-                        northTile.MarkFreeToMove();
+                        northTile.MarkMoveTarget();
                         _MoveCandidates.Add(northTile);
                     }
                 }
@@ -691,7 +691,7 @@ namespace DungeonDiceMonsters
                     if (!(southTile.IsOccupied))
                     {
                         //Change the Adjencent tile's border to gree to mark that you can move
-                        southTile.MarkFreeToMove();
+                        southTile.MarkMoveTarget();
                         _MoveCandidates.Add(southTile);
                     }
                 }
@@ -705,7 +705,7 @@ namespace DungeonDiceMonsters
                     if (!(eastTile.IsOccupied))
                     {
                         //Change the Adjencent tile's border to gree to mark that you can move
-                        eastTile.MarkFreeToMove();
+                        eastTile.MarkMoveTarget();
                         _MoveCandidates.Add(eastTile);
                     }
                 }
@@ -719,7 +719,7 @@ namespace DungeonDiceMonsters
                     if (!(westTile.IsOccupied))
                     {
                         //Change the Adjencent tile's border to gree to mark that you can move
-                        westTile.MarkFreeToMove();
+                        westTile.MarkMoveTarget();
                         _MoveCandidates.Add(westTile);
                     }
                 }

--- a/DungeonDiceMonsters/Board Elements/Card.cs
+++ b/DungeonDiceMonsters/Board Elements/Card.cs
@@ -128,6 +128,7 @@ namespace DungeonDiceMonsters
         public int MovesPerTurn { get { return _BaseMovesPerTurn; } }
         public bool EffectUsedThisTurn { get { return _EffectUsedThisTurn; } }
         public int AttackRange { get { return _AttackRange; } }
+        public int MoveRange { get { return _MoveRange; } }
         #endregion
 
         #region Public Funtions
@@ -314,7 +315,7 @@ namespace DungeonDiceMonsters
 
         //Ranges
         private int _AttackRange = 1;
-        //TODO: private int _MoveRango = 1;
+        private int _MoveRange = 1;
 
         //Effects
         private Effect _OnSummonEffectObject;

--- a/DungeonDiceMonsters/Board Elements/Tile.cs
+++ b/DungeonDiceMonsters/Board Elements/Tile.cs
@@ -210,197 +210,7 @@ namespace DungeonDiceMonsters
             _card = null;
             _Occupied = false;            
             ReloadTileUI();
-        }
-        public List<Tile> GetAttackRangeTiles(bool returnCandidatesOnly)
-        {
-            List<Tile> tiles = new List<Tile>();
-
-            //Set the attack range to use
-            int attackRange = _card.AttackRange;
-
-            //Gather the north tiles
-            for (int i = 0; i < attackRange; i++)
-            {
-                List<TileDirection> northDirections = new List<TileDirection>();
-                for (int j = 0; j <= i; j++)
-                {
-                    northDirections.Add(TileDirection.North);
-                }
-                Tile thisNorthTile = GetTileInDirection(northDirections);
-                if (thisNorthTile == null) 
-                {
-                    break;
-                }
-                else
-                {
-                    if (thisNorthTile.IsActive)
-                    {                      
-                        if(returnCandidatesOnly)
-                        {
-                            if(thisNorthTile.IsOccupied)
-                            {
-                                if(thisNorthTile.CardInPlace.Owner != _card.Owner)
-                                {
-                                    tiles.Add(thisNorthTile);
-                                }
-
-                            }
-                        }
-                        else
-                        {
-                            tiles.Add(thisNorthTile);
-                        }
-
-                        //If this tile was occupied break the loop
-                        if (thisNorthTile.IsOccupied)
-                        {
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }               
-            }
-
-            //Gather the south tiles
-            for (int i = 0; i < attackRange; i++)
-            {
-                List<TileDirection> southDirections = new List<TileDirection>();
-                for (int j = 0; j <= i; j++)
-                {
-                    southDirections.Add(TileDirection.South);
-                }
-                Tile thisSouthTile = GetTileInDirection(southDirections);
-                if (thisSouthTile == null)
-                {
-                    break;
-                }
-                else
-                {
-                    if (thisSouthTile.IsActive)
-                    {
-                        if (returnCandidatesOnly)
-                        {
-                            if (thisSouthTile.IsOccupied)
-                            {
-                                if (thisSouthTile.CardInPlace.Owner != _card.Owner)
-                                {
-                                    tiles.Add(thisSouthTile);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            tiles.Add(thisSouthTile);
-                        }
-
-                        //If this tile was occupied break the loop
-                        if (thisSouthTile.IsOccupied)
-                        {
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
-
-            //Gather the east tiles
-            for (int i = 0; i < attackRange; i++)
-            {
-                List<TileDirection> eastDirections = new List<TileDirection>();
-                for (int j = 0; j <= i; j++)
-                {
-                    eastDirections.Add(TileDirection.East);
-                }
-                Tile thisEastTile = GetTileInDirection(eastDirections);
-                if (thisEastTile == null)
-                {
-                    break;
-                }
-                else
-                {
-                    if (thisEastTile.IsActive)
-                    {
-                        if (returnCandidatesOnly)
-                        {
-                            if (thisEastTile.IsOccupied)
-                            {
-                                if (thisEastTile.CardInPlace.Owner != _card.Owner)
-                                {
-                                    tiles.Add(thisEastTile);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            tiles.Add(thisEastTile);
-                        }
-
-                        //If this tile was occupied break the loop
-                        if (thisEastTile.IsOccupied)
-                        {
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
-
-            //Gather the west tiles
-            for (int i = 0; i < attackRange; i++)
-            {
-                List<TileDirection> westDirections = new List<TileDirection>();
-                for (int j = 0; j <= i; j++)
-                {
-                    westDirections.Add(TileDirection.West);
-                }
-                Tile thisWestTile = GetTileInDirection(westDirections);
-                if (thisWestTile == null)
-                {
-                    break;
-                }
-                else
-                {
-                    if (thisWestTile.IsActive)
-                    {
-                        if (returnCandidatesOnly)
-                        {
-                            if (thisWestTile.IsOccupied)
-                            {
-                                if (thisWestTile.CardInPlace.Owner != _card.Owner)
-                                {
-                                    tiles.Add(thisWestTile);
-                                }
-                            }
-                        }
-                        else
-                        {
-                            tiles.Add(thisWestTile);
-                        }
-
-                        //If this tile was occupied break the loop
-                        if (thisWestTile.IsOccupied)
-                        {
-                            break;
-                        }
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
-
-            return tiles;
-        }
+        }       
         public bool HasAnAdjecentTileOwnBy(PlayerColor expectedOwner)
         {
             bool hasIt = false;
@@ -439,8 +249,9 @@ namespace DungeonDiceMonsters
 
             return hasIt;
         }     
-        public void MarkFreeToMove()
+        public void MarkMoveTarget()
         {
+            _Border.BackColor = Color.Yellow;
             _CardImage.BackColor = Color.Green;
             //In case the tile has a field type set, remove the card image temparely
             if (_CardImage.BackgroundImage != null) { _CardImage.BackgroundImage.Dispose(); _CardImage.BackgroundImage = null; }
@@ -1049,6 +860,337 @@ namespace DungeonDiceMonsters
             if (tileG7 != null) { if (tileG7.Owner != PlayerColor.NONE) tiles.Add(tileG7); }
 
             if (returnCandidatesOnly) { return tiles; } else { return Alltiles; }
+        }
+        public List<Tile> GetAttackRangeTiles(bool returnCandidatesOnly)
+        {
+            List<Tile> tiles = new List<Tile>();
+
+            //Set the attack range to use
+            int attackRange = _card.AttackRange;
+
+            //Gather the north tiles
+            for (int i = 0; i < attackRange; i++)
+            {
+                List<TileDirection> northDirections = new List<TileDirection>();
+                for (int j = 0; j <= i; j++)
+                {
+                    northDirections.Add(TileDirection.North);
+                }
+                Tile thisNorthTile = GetTileInDirection(northDirections);
+                if (thisNorthTile == null)
+                {
+                    break;
+                }
+                else
+                {
+                    if (thisNorthTile.IsActive)
+                    {
+                        if (returnCandidatesOnly)
+                        {
+                            if (thisNorthTile.IsOccupied)
+                            {
+                                if (thisNorthTile.CardInPlace.Owner != _card.Owner)
+                                {
+                                    tiles.Add(thisNorthTile);
+                                }
+
+                            }
+                        }
+                        else
+                        {
+                            tiles.Add(thisNorthTile);
+                        }
+
+                        //If this tile was occupied break the loop
+                        if (thisNorthTile.IsOccupied)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            //Gather the south tiles
+            for (int i = 0; i < attackRange; i++)
+            {
+                List<TileDirection> southDirections = new List<TileDirection>();
+                for (int j = 0; j <= i; j++)
+                {
+                    southDirections.Add(TileDirection.South);
+                }
+                Tile thisSouthTile = GetTileInDirection(southDirections);
+                if (thisSouthTile == null)
+                {
+                    break;
+                }
+                else
+                {
+                    if (thisSouthTile.IsActive)
+                    {
+                        if (returnCandidatesOnly)
+                        {
+                            if (thisSouthTile.IsOccupied)
+                            {
+                                if (thisSouthTile.CardInPlace.Owner != _card.Owner)
+                                {
+                                    tiles.Add(thisSouthTile);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            tiles.Add(thisSouthTile);
+                        }
+
+                        //If this tile was occupied break the loop
+                        if (thisSouthTile.IsOccupied)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            //Gather the east tiles
+            for (int i = 0; i < attackRange; i++)
+            {
+                List<TileDirection> eastDirections = new List<TileDirection>();
+                for (int j = 0; j <= i; j++)
+                {
+                    eastDirections.Add(TileDirection.East);
+                }
+                Tile thisEastTile = GetTileInDirection(eastDirections);
+                if (thisEastTile == null)
+                {
+                    break;
+                }
+                else
+                {
+                    if (thisEastTile.IsActive)
+                    {
+                        if (returnCandidatesOnly)
+                        {
+                            if (thisEastTile.IsOccupied)
+                            {
+                                if (thisEastTile.CardInPlace.Owner != _card.Owner)
+                                {
+                                    tiles.Add(thisEastTile);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            tiles.Add(thisEastTile);
+                        }
+
+                        //If this tile was occupied break the loop
+                        if (thisEastTile.IsOccupied)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            //Gather the west tiles
+            for (int i = 0; i < attackRange; i++)
+            {
+                List<TileDirection> westDirections = new List<TileDirection>();
+                for (int j = 0; j <= i; j++)
+                {
+                    westDirections.Add(TileDirection.West);
+                }
+                Tile thisWestTile = GetTileInDirection(westDirections);
+                if (thisWestTile == null)
+                {
+                    break;
+                }
+                else
+                {
+                    if (thisWestTile.IsActive)
+                    {
+                        if (returnCandidatesOnly)
+                        {
+                            if (thisWestTile.IsOccupied)
+                            {
+                                if (thisWestTile.CardInPlace.Owner != _card.Owner)
+                                {
+                                    tiles.Add(thisWestTile);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            tiles.Add(thisWestTile);
+                        }
+
+                        //If this tile was occupied break the loop
+                        if (thisWestTile.IsOccupied)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return tiles;
+        }
+        public List<Tile> GetMoveRangeTiles()
+        {
+            List<Tile> tiles = new List<Tile>();
+
+            //Set the attack range to use
+            int moveRange = _card.MoveRange;
+
+            //Gather the north tiles
+            for (int i = 0; i < moveRange; i++)
+            {
+                List<TileDirection> northDirections = new List<TileDirection>();
+                for (int j = 0; j <= i; j++)
+                {
+                    northDirections.Add(TileDirection.North);
+                }
+                Tile thisNorthTile = GetTileInDirection(northDirections);
+                if (thisNorthTile == null)
+                {
+                    break;
+                }
+                else
+                {
+                    if (thisNorthTile.IsActive)
+                    {
+                        if (thisNorthTile.IsOccupied)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            tiles.Add(thisNorthTile);
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            //Gather the south tiles
+            for (int i = 0; i < moveRange; i++)
+            {
+                List<TileDirection> southDirections = new List<TileDirection>();
+                for (int j = 0; j <= i; j++)
+                {
+                    southDirections.Add(TileDirection.South);
+                }
+                Tile thisSouthTile = GetTileInDirection(southDirections);
+                if (thisSouthTile == null)
+                {
+                    break;
+                }
+                else
+                {
+                    if (thisSouthTile.IsActive)
+                    {
+                        if (thisSouthTile.IsOccupied)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            tiles.Add(thisSouthTile);
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            //Gather the east tiles
+            for (int i = 0; i < moveRange; i++)
+            {
+                List<TileDirection> eastDirections = new List<TileDirection>();
+                for (int j = 0; j <= i; j++)
+                {
+                    eastDirections.Add(TileDirection.East);
+                }
+                Tile thisEastTile = GetTileInDirection(eastDirections);
+                if (thisEastTile == null)
+                {
+                    break;
+                }
+                else
+                {
+                    if (thisEastTile.IsActive)
+                    {
+                        if (thisEastTile.IsOccupied)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            tiles.Add(thisEastTile);
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            //Gather the west tiles
+            for (int i = 0; i < moveRange; i++)
+            {
+                List<TileDirection> westDirections = new List<TileDirection>();
+                for (int j = 0; j <= i; j++)
+                {
+                    westDirections.Add(TileDirection.West);
+                }
+                Tile thisWestTile = GetTileInDirection(westDirections);
+                if (thisWestTile == null)
+                {
+                    break;
+                }
+                else
+                {
+                    if (thisWestTile.IsActive)
+                    {
+                        if (thisWestTile.IsOccupied)
+                        {
+                            break;
+                        }
+                        else
+                        {
+                            tiles.Add(thisWestTile);
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return tiles;
         }
         #endregion
 

--- a/DungeonDiceMonsters/BoardPvP.cs
+++ b/DungeonDiceMonsters/BoardPvP.cs
@@ -866,25 +866,12 @@ namespace DungeonDiceMonsters
         private void DisplayMoveCandidates()
         {
             //Clear the current candidate list
-            _MoveCandidates.Clear();
+            _MoveCandidates = _PreviousTileMove.GetMoveRangeTiles();
 
-            //Check each adjencent tile in every direction, if the Tile is Active and is not occupied, then it is a move candidate
-            List<Tile.TileDirection> DirectionsToCheck = new List<Tile.TileDirection>() { Tile.TileDirection.North, Tile.TileDirection.South, Tile.TileDirection.East, Tile.TileDirection.West };
-            foreach(Tile.TileDirection thisDirection in DirectionsToCheck)
+            //Mark the candidate tiles
+            foreach(Tile thisTile in _MoveCandidates)
             {
-                if (_PreviousTileMove.HasAnAdjecentTile(thisDirection))
-                {
-                    Tile thisTile = _PreviousTileMove.GetAdjencentTile(thisDirection);
-                    if (thisTile.Owner != PlayerColor.NONE)
-                    {
-                        if (!thisTile.IsOccupied)
-                        {
-                            //Change the Adjencent tile's border to gree to mark that you can move
-                            thisTile.MarkFreeToMove();
-                            _MoveCandidates.Add(thisTile);
-                        }
-                    }
-                }
+                thisTile.MarkMoveTarget();
             }
         }
         private void DisplaySetCandidates()
@@ -3291,11 +3278,7 @@ namespace DungeonDiceMonsters
 
                 //Attack the card in this tile
                 _AttackTarger = _Tiles[tileId];
-
-                //if the card is facedow, flip it
-                _AttackTarger.CardInPlace.FlipFaceUp();
-                WaitNSeconds(1000);
-
+               
                 //Close the Attack Menu and Reset the UI of all the Attack Range Tiles
                 PanelAttackMenu.Visible = false;               
                 foreach (Tile tile in _AttackRangeTiles)
@@ -3309,6 +3292,10 @@ namespace DungeonDiceMonsters
 
                 //Intructions message can be hidden for both players during the battle phase
                 lblActionInstruction.Visible = false;
+
+                //if the card is facedow, flip it
+                _AttackTarger.CardInPlace.FlipFaceUp();
+                WaitNSeconds(1000);
 
                 //Open the Battle Panel
                 OpenBattleMenu();
@@ -3685,7 +3672,7 @@ namespace DungeonDiceMonsters
             {
                 foreach (Tile thisTile in _FusionSummonTiles)
                 {
-                    thisTile.MarkFreeToMove();
+                    thisTile.MarkMoveTarget();
                 }
 
                 if (UserPlayerColor == TURNPLAYER)


### PR DESCRIPTION
Cards can now move the number of tiles up to the value of their "Move Range" per single move action (in a straight line) This can now enable effects/ability to allow cards to move multiple tiles per [MOV] used.