### PR TITLE
Tile hovering enable during the "Moving Card" game state

### DIFF
--- a/DungeonDiceMonsters/Board Elements/Tile.cs
+++ b/DungeonDiceMonsters/Board Elements/Tile.cs
@@ -269,7 +269,6 @@ namespace DungeonDiceMonsters
         }     
         public void MarkMoveTarget()
         {
-            _Border.BackColor = Color.Yellow;
             _CardImage.BackColor = Color.Green;
             //In case the tile has a field type set, remove the card image temparely
             if (_CardImage.BackgroundImage != null) { _CardImage.BackgroundImage.Dispose(); _CardImage.BackgroundImage = null; }

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
@@ -71,8 +71,8 @@ namespace DungeonDiceMonsters
             {
                 Tile thisTile = _Tiles[tileId];
                 if (_CurrentGameState == GameState.BoardViewMode || _CurrentGameState == GameState.MainPhaseBoard ||
-                    _CurrentGameState == GameState.SetCard || _CurrentGameState == GameState.FusionMaterialCandidateSelection 
-                    || _CurrentGameState == GameState.FusionSummonTileSelection)
+                _CurrentGameState == GameState.SetCard || _CurrentGameState == GameState.FusionMaterialCandidateSelection
+                || _CurrentGameState == GameState.FusionSummonTileSelection || _CurrentGameState == GameState.MovingCard)
                 {
                     SoundServer.PlaySoundEffect(SoundEffect.Hover);
                     thisTile.Hover();
@@ -146,6 +146,14 @@ namespace DungeonDiceMonsters
                     if (_FusionSummonTiles.Contains(thisTile))
                     {
                         thisTile.MarkFusionSummonTile();
+                    }
+                }
+                else if (_CurrentGameState == GameState.MovingCard)
+                {
+                    thisTile.ReloadTileUI();
+                    if (_MoveCandidates.Contains(thisTile))
+                    {
+                        thisTile.MarkMoveTarget();
                     }
                 }
             }));

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP_EventListeners.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP_EventListeners.cs
@@ -3,6 +3,7 @@
 //Partial Class for BoardPvP (Event Listeners)
 
 using System;
+using System.Collections.Generic;
 using System.Windows.Forms;
 
 namespace DungeonDiceMonsters
@@ -86,10 +87,19 @@ namespace DungeonDiceMonsters
             //Only allow this event if the user is the TURN PLAYER
             if (UserPlayerColor == TURNPLAYER && _CurrentGameState != GameState.NOINPUT)
             {
+                List<GameState> StatesElegible = new List<GameState> 
+                {
+                    GameState.BoardViewMode,
+                    GameState.MainPhaseBoard,
+                    GameState.SummonCard,
+                    GameState.SetCard,
+                    GameState.FusionMaterialCandidateSelection,
+                    GameState.FusionSummonTileSelection,
+                    GameState.MovingCard,
+                };
+
                 //Send the action message to the server
-                if ((_CurrentGameState == GameState.BoardViewMode || _CurrentGameState == GameState.MainPhaseBoard ||
-                    _CurrentGameState == GameState.SummonCard || _CurrentGameState == GameState.SetCard ||
-                    _CurrentGameState == GameState.FusionMaterialCandidateSelection || _CurrentGameState == GameState.FusionSummonTileSelection))
+                if (StatesElegible.Contains(_CurrentGameState))
                 {
                     SendMessageToServer(string.Format("{0}|{1}|{2}", "[ON MOUSE ENTER TILE]", _CurrentGameState.ToString(), tileID.ToString()));
 
@@ -116,10 +126,19 @@ namespace DungeonDiceMonsters
         {
             if (UserPlayerColor == TURNPLAYER && _CurrentGameState != GameState.NOINPUT)
             {
+                List<GameState> StatesElegible = new List<GameState>
+                {
+                    GameState.BoardViewMode,
+                    GameState.MainPhaseBoard,
+                    GameState.SummonCard,
+                    GameState.SetCard,
+                    GameState.FusionMaterialCandidateSelection,
+                    GameState.FusionSummonTileSelection,
+                    GameState.MovingCard,
+                };
+
                 //Send the action message to the server
-                if ((_CurrentGameState == GameState.BoardViewMode || _CurrentGameState == GameState.MainPhaseBoard ||
-                    _CurrentGameState == GameState.SummonCard || _CurrentGameState == GameState.SetCard ||
-                     _CurrentGameState == GameState.FusionMaterialCandidateSelection || _CurrentGameState == GameState.FusionSummonTileSelection))
+                if (StatesElegible.Contains(_CurrentGameState))
                 {
                     SendMessageToServer(string.Format("{0}|{1}|{2}", "[ON MOUSE LEAVE TILE]", _CurrentGameState.ToString(), tileID.ToString()));
 


### PR DESCRIPTION
Turn player can now hover tiles on the board while selecting tiles for moving and the opponent can follow along with the actions.

Move Tile candidates have been update to only show the green backcolor on the inside picture without border. It works better with the hovering enable.