### PR TITLE
Tile hovering in the "Selecting Attack Target" game state.

### DIFF
--- a/DungeonDiceMonsters/Board Elements/Tile.cs
+++ b/DungeonDiceMonsters/Board Elements/Tile.cs
@@ -279,6 +279,10 @@ namespace DungeonDiceMonsters
             _OverlayIcon.Image = ImageServer.AttackTargetIcon();
             _OverlayIcon.Visible = true;
         }
+        public void HighlightAttackRange()
+        {
+            _Border.BackColor = Color.Orange;
+        }
         public void MarkEffectTarget()
         {
             _Border.BackColor = Color.Green;

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
@@ -72,7 +72,8 @@ namespace DungeonDiceMonsters
                 Tile thisTile = _Tiles[tileId];
                 if (_CurrentGameState == GameState.BoardViewMode || _CurrentGameState == GameState.MainPhaseBoard ||
                 _CurrentGameState == GameState.SetCard || _CurrentGameState == GameState.FusionMaterialCandidateSelection
-                || _CurrentGameState == GameState.FusionSummonTileSelection || _CurrentGameState == GameState.MovingCard)
+                || _CurrentGameState == GameState.FusionSummonTileSelection || _CurrentGameState == GameState.MovingCard 
+                || _CurrentGameState == GameState.SelectingAttackTarger)
                 {
                     SoundServer.PlaySoundEffect(SoundEffect.Hover);
                     thisTile.Hover();
@@ -154,6 +155,20 @@ namespace DungeonDiceMonsters
                     if (_MoveCandidates.Contains(thisTile))
                     {
                         thisTile.MarkMoveTarget();
+                    }
+                }
+                else if (_CurrentGameState == GameState.SelectingAttackTarger)
+                {
+                    thisTile.ReloadTileUI();
+
+                    if(_AttackRangeTiles.Contains(thisTile))
+                    {
+                        thisTile.HighlightAttackRange();
+                    }
+
+                    if(_AttackCandidates.Contains(thisTile))
+                    {
+                        thisTile.MarkAttackTarget();
                     }
                 }
             }));
@@ -870,7 +885,7 @@ namespace DungeonDiceMonsters
                 //First highlight all the tiles within the attack range
                 foreach (Tile thisTile in AttackRangeTiles)
                 {
-                    thisTile.HighlightTile();
+                    thisTile.HighlightAttackRange();    
                 }
                 //Then place the attack target overlay icon on the attack target candidates
                 foreach (Tile tile in _AttackCandidates)

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP_EventListeners.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP_EventListeners.cs
@@ -96,6 +96,7 @@ namespace DungeonDiceMonsters
                     GameState.FusionMaterialCandidateSelection,
                     GameState.FusionSummonTileSelection,
                     GameState.MovingCard,
+                    GameState.SelectingAttackTarger,
                 };
 
                 //Send the action message to the server
@@ -135,6 +136,7 @@ namespace DungeonDiceMonsters
                     GameState.FusionMaterialCandidateSelection,
                     GameState.FusionSummonTileSelection,
                     GameState.MovingCard,
+                    GameState.SelectingAttackTarger,
                 };
 
                 //Send the action message to the server


### PR DESCRIPTION
Attack Range tiles are now highlighted in Orange so it doesnt conflict with the hovering yellow highlight.