### PR TITLE
Symbols' "ReactTo_MonsterSummon" now is "ReactTo_NewMonsterUnderYourControl"

### DIFF
--- a/DungeonDiceMonsters/Board Elements/Card.cs
+++ b/DungeonDiceMonsters/Board Elements/Card.cs
@@ -9,11 +9,11 @@ namespace DungeonDiceMonsters
     public class Card
     {
         #region Constructors
-        public Card(int id, CardInfo info, PlayerColor owner, bool isFaceDown)
+        public Card(int id, CardInfo info, PlayerColor controller, bool isFaceDown)
         {
             _id = id;
             _cardInfo = info;
-            _Owner = owner;
+            _Controller = controller;
             _CurrentLP = _cardInfo.LP;
             _IsFaceDown = isFaceDown;
             if(HasAbility)
@@ -49,7 +49,7 @@ namespace DungeonDiceMonsters
         {
             _id = id;
             _cardInfo = new CardInfo(attribute);
-            _Owner = owner;
+            _Controller = Controller;
             _CurrentLP = _cardInfo.LP;
             _IsASymbol = true;
             _CurrentAttribute = _cardInfo.Attribute;
@@ -91,7 +91,7 @@ namespace DungeonDiceMonsters
 
         #region On Board Data
         public int OnBoardID { get { return _id; } }       
-        public PlayerColor Owner { get { return _Owner; } }
+        public PlayerColor Controller { get { return _Controller; } }
         public bool IsFaceDown { get { return _IsFaceDown; } }
         public bool IsDiscardted { get { return _IsDestroyed; } }
         public bool IsASymbol { get { return _IsASymbol; } }
@@ -287,7 +287,7 @@ namespace DungeonDiceMonsters
         //Card Board Data
         private int _id = -1;
         private CardInfo _cardInfo;
-        private PlayerColor _Owner;
+        private PlayerColor _Controller;
         private bool _IsDestroyed = false;
         private bool _IsFaceDown = false;
         private bool _IsASymbol = false;

--- a/DungeonDiceMonsters/Board Elements/Effect.cs
+++ b/DungeonDiceMonsters/Board Elements/Effect.cs
@@ -24,7 +24,7 @@ namespace DungeonDiceMonsters
         #region Public Methods
         public Card OriginCard { get { return _OriginCard; } }
         public EffectID ID { get { return _ID; } }
-        public PlayerColor Owner{ get { return _OriginCard.Owner; } }
+        public PlayerColor Owner{ get { return _OriginCard.Controller; } }
         public EffectType Type { get { return _Type; } }
         public bool IsAOneTurnIgnition { get { return _IsOneTurnIgnition; } }
         public List<Card> AffectedByList { get { return _AffectedByList; } }
@@ -57,6 +57,7 @@ namespace DungeonDiceMonsters
         public bool ReactsToMonsterSummon { get; set; }
         public bool ReactsToMonsterDestroyed { get; set; }
         public bool ReactsToAttributeChange { get; set; }
+        public bool ReactsToMonsterControlChange { get; set; }
         #endregion
 
         #region Private Methods

--- a/DungeonDiceMonsters/Board Elements/Tile.cs
+++ b/DungeonDiceMonsters/Board Elements/Tile.cs
@@ -926,7 +926,7 @@ namespace DungeonDiceMonsters
                         {
                             if (thisNorthTile.IsOccupied)
                             {
-                                if (thisNorthTile.CardInPlace.Owner != _card.Owner)
+                                if (thisNorthTile.CardInPlace.Controller != _card.Controller)
                                 {
                                     tiles.Add(thisNorthTile);
                                 }
@@ -972,7 +972,7 @@ namespace DungeonDiceMonsters
                         {
                             if (thisSouthTile.IsOccupied)
                             {
-                                if (thisSouthTile.CardInPlace.Owner != _card.Owner)
+                                if (thisSouthTile.CardInPlace.Controller != _card.Controller)
                                 {
                                     tiles.Add(thisSouthTile);
                                 }
@@ -1017,7 +1017,7 @@ namespace DungeonDiceMonsters
                         {
                             if (thisEastTile.IsOccupied)
                             {
-                                if (thisEastTile.CardInPlace.Owner != _card.Owner)
+                                if (thisEastTile.CardInPlace.Controller != _card.Controller)
                                 {
                                     tiles.Add(thisEastTile);
                                 }
@@ -1062,7 +1062,7 @@ namespace DungeonDiceMonsters
                         {
                             if (thisWestTile.IsOccupied)
                             {
-                                if (thisWestTile.CardInPlace.Owner != _card.Owner)
+                                if (thisWestTile.CardInPlace.Controller != _card.Controller)
                                 {
                                     tiles.Add(thisWestTile);
                                 }

--- a/DungeonDiceMonsters/BoardPvP/BoardForm.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardForm.cs
@@ -537,7 +537,7 @@ namespace DungeonDiceMonsters
                 int cardID = thisCard.CardID;
 
                 //Set the Panel Back Color based on whose the card owner
-                if (_CurrentTileSelected.CardInPlace.Owner == PlayerColor.RED)
+                if (_CurrentTileSelected.CardInPlace.Controller == PlayerColor.RED)
                 {
                     PanelCardInfo.BackColor = Color.DarkRed;
                 }
@@ -546,7 +546,7 @@ namespace DungeonDiceMonsters
                     PanelCardInfo.BackColor = Color.DarkBlue;
                 }
 
-                if(thisCard.IsFaceDown && thisCard.Owner == PlayerColor.BLUE)
+                if(thisCard.IsFaceDown && thisCard.Controller == PlayerColor.BLUE)
                 {
                     PicCardArtworkBottom.Image = ImageServer.CardArtworkImage("0");
 
@@ -565,7 +565,7 @@ namespace DungeonDiceMonsters
                     {
                         PicCardArtworkBottom.Image = ImageServer.Symbol(thisCard.CurrentAttribute.ToString());
 
-                        lblCardName.Text = thisCard.Owner + "'s " + thisCard.Name;
+                        lblCardName.Text = thisCard.Controller + "'s " + thisCard.Name;
                         lblCardType.Text = "";
                         lblCardLevel.Text = "";
                         lblAttribute.Text = thisCard.CurrentAttribute.ToString();
@@ -860,7 +860,7 @@ namespace DungeonDiceMonsters
             if (_CurrentTileSelected.IsOccupied)
             {
                 lblDebugCard.Text = "Card: " + _CurrentTileSelected.CardInPlace.CardID + "-Name:" + _CurrentTileSelected.CardInPlace.Name;
-                lblDebugCardOwner.Text = "Card Owner: " + _CurrentTileSelected.CardInPlace.Owner;
+                lblDebugCardOwner.Text = "Card Owner: " + _CurrentTileSelected.CardInPlace.Controller;
             }
             else
             {
@@ -949,7 +949,7 @@ namespace DungeonDiceMonsters
             {
                 if (_CurrentTileSelected.IsOccupied)
                 {
-                    if (_CurrentTileSelected.CardInPlace.Owner == PlayerColor.RED)
+                    if (_CurrentTileSelected.CardInPlace.Controller == PlayerColor.RED)
                     {
                         SoundServer.PlaySoundEffect(SoundEffect.Click);
 

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP.cs
@@ -666,7 +666,7 @@ namespace DungeonDiceMonsters
                 int cardID = thisCard.CardID;
 
                 //Set the Panel Back Color based on whose the card owner
-                if (thisCard.Owner == PlayerColor.RED)
+                if (thisCard.Controller == PlayerColor.RED)
                 {
                     PanelCardInfo.BackColor = Color.DarkRed;
                 }
@@ -675,7 +675,7 @@ namespace DungeonDiceMonsters
                     PanelCardInfo.BackColor = Color.DarkBlue;
                 }
 
-                if (thisCard.IsFaceDown && thisCard.Owner != UserPlayerColor)
+                if (thisCard.IsFaceDown && thisCard.Controller != UserPlayerColor)
                 {
                     PicCardArtworkBottom.Image = ImageServer.CardArtworkImage("0");
 
@@ -705,7 +705,7 @@ namespace DungeonDiceMonsters
                     {
                         PicCardArtworkBottom.Image = ImageServer.Symbol(thisCard.CurrentAttribute.ToString());
 
-                        lblCardName.Text = thisCard.Owner + "'s " + thisCard.Name;
+                        lblCardName.Text = thisCard.Controller + "'s " + thisCard.Name;
                         lblCardType.Text = string.Empty;
                         lblCardLevel.Text = string.Empty;
                         PicCardAttribute.Image = ImageServer.AttributeIcon(thisCard.CurrentAttribute);
@@ -997,7 +997,7 @@ namespace DungeonDiceMonsters
                 if (_CurrentTileSelected.IsOccupied)
                 {
                     lblDebugCard.Text = "Card: " + _CurrentTileSelected.CardInPlace.CardID + "-Name:" + _CurrentTileSelected.CardInPlace.Name;
-                    lblDebugCardOwner.Text = "Card Owner: " + _CurrentTileSelected.CardInPlace.Owner;
+                    lblDebugCardOwner.Text = "Card Owner: " + _CurrentTileSelected.CardInPlace.Controller;
                 }
                 else
                 {
@@ -1104,7 +1104,7 @@ namespace DungeonDiceMonsters
             WaitNSeconds(1000);
 
             //Check for active effects that react to monster summons
-            UpdateEffectLogs(string.Format(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>Card Summoned: [{0}] On Board ID: [{1}] Owned By: [{2}]", thisCard.Name, thisCard.OnBoardID, thisCard.Owner));
+            UpdateEffectLogs(string.Format(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>Card Summoned: [{0}] On Board ID: [{1}] Owned By: [{2}]", thisCard.Name, thisCard.OnBoardID, thisCard.Controller));
             ResolveEffectsWithSummonReactionTo(thisCard);
 
             //Now check if the Monster has an "On Summon"/"Continuous" effect and try to activate
@@ -1136,12 +1136,12 @@ namespace DungeonDiceMonsters
                         UpdateEffectLogs(string.Format("Reaction Check for Effect: [{0}] Origin Card Board ID: [{1}]", thisActiveEffect.ID, thisActiveEffect.OriginCard.OnBoardID));
                         switch (thisActiveEffect.ID)
                         {
-                            case Effect.EffectID.DARKSymbol: DarkSymbol_ReactTo_MonsterSummon(thisActiveEffect, targetCard); break;
-                            case Effect.EffectID.LIGHTSymbol: LightSymbol_ReactTo_MonsterSummon(thisActiveEffect, targetCard); break;
-                            case Effect.EffectID.WATERSymbol: WaterSymbol_ReactTo_MonsterSummon(thisActiveEffect, targetCard); break;
-                            case Effect.EffectID.FIRESymbol: FireSymbol_ReactTo_MonsterSummon(thisActiveEffect, targetCard); break;
-                            case Effect.EffectID.EARTHSymbol: EarthSymbol_ReactTo_MonsterSummon(thisActiveEffect, targetCard); break;
-                            case Effect.EffectID.WINDSymbol: WindSymbol_ReactTo_MonsterSummon(thisActiveEffect, targetCard); break;
+                            case Effect.EffectID.DARKSymbol: DarkSymbol_ReactTo_NewMonsterUnderYourControl(thisActiveEffect, targetCard); break;
+                            case Effect.EffectID.LIGHTSymbol: LightSymbol_ReactTo_NewMonsterUnderYourControl(thisActiveEffect, targetCard); break;
+                            case Effect.EffectID.WATERSymbol: WaterSymbol_ReactTo_NewMonsterUnderYourControl(thisActiveEffect, targetCard); break;
+                            case Effect.EffectID.FIRESymbol: FireSymbol_ReactTo_NewMonsterUnderYourControl(thisActiveEffect, targetCard); break;
+                            case Effect.EffectID.EARTHSymbol: EarthSymbol_ReactTo_NewMonsterUnderYourControl(thisActiveEffect, targetCard); break;
+                            case Effect.EffectID.WINDSymbol: WindSymbol_ReactTo_NewMonsterUnderYourControl(thisActiveEffect, targetCard); break;
                             case Effect.EffectID.KarbonalaWarrior_Continuous: KarbonalaWarrior_ReactTo_MonsterSummon(thisActiveEffect, targetCard); break;
                             case Effect.EffectID.ThunderDragon_Continuous: ThunderDragon_TryToApplyToNewCard(thisActiveEffect, targetCard); break;
                             default: throw new Exception(string.Format("Effect ID: [{0}] does not have an EffectToApply Function", thisActiveEffect.ID));
@@ -1161,7 +1161,7 @@ namespace DungeonDiceMonsters
             //and update the UI to show the card is gone
             tileLocation.DestroyCard();
 
-            UpdateEffectLogs(string.Format(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Card Destroyed: [{0}] On Board ID: [{1}] Owned by: [{2}]", thisCard.Name, thisCard.OnBoardID, thisCard.Owner));
+            UpdateEffectLogs(string.Format(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>Card Destroyed: [{0}] On Board ID: [{1}] Owned by: [{2}]", thisCard.Name, thisCard.OnBoardID, thisCard.Controller));
 
 
             //Now check if this card had any active Continuous effect, if so, remove the effect and revert the effect changes

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
@@ -1115,7 +1115,7 @@ namespace DungeonDiceMonsters
                                     {
                                         Card thisCardOnTheBoard = _CardsOnBoard[x];
                                         if (thisCardOnTheBoard.Name == thisMeterial && !thisCardOnTheBoard.IsDiscardted &&
-                                            thisCardOnTheBoard.Owner == TURNPLAYER && !candidatesFound.Contains(x))
+                                            thisCardOnTheBoard.Controller == TURNPLAYER && !candidatesFound.Contains(x))
                                         {
                                             candidatesFound.Add(x);
                                             break;
@@ -1154,7 +1154,7 @@ namespace DungeonDiceMonsters
                         bool monsterFound = false;
                         foreach (Card thisBoardCard in _CardsOnBoard)
                         {
-                            if (!thisBoardCard.IsDiscardted && thisBoardCard.Owner == OPPONENTPLAYER)
+                            if (!thisBoardCard.IsDiscardted && thisBoardCard.Controller == OPPONENTPLAYER)
                             {
                                 monsterFound = true;
                                 break;

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP_EventListeners.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP_EventListeners.cs
@@ -172,7 +172,7 @@ namespace DungeonDiceMonsters
                 {
                     if (thisTile.IsOccupied)
                     {
-                        if (thisTile.CardInPlace.Owner == UserPlayerColor)
+                        if (thisTile.CardInPlace.Controller == UserPlayerColor)
                         {
                             _CurrentGameState = GameState.NOINPUT;
 


### PR DESCRIPTION
The symbol's "ReactTo_NewMonsterUnderYourControl" should execute either when a monster is summon or when a monster's controller is changed. The logic for ReactTo_MonsterSummon and ReactTo_MonsterControlChanged will be the same EXACT, so I decided to create a single ReactTo_ method to execute any of the 2 react events.

Also Card Object's "Owner" field now becomes "Controller"