### PR TITLE
[ATK] reduced during attack declaration implemented

### DIFF
--- a/DungeonDiceMonsters/BoardPvP/BoardPvP.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP.cs
@@ -1799,15 +1799,15 @@ namespace DungeonDiceMonsters
                     }
 
                     //Step 4: Reduce the [ATK] and [DEF] to the respective player.                   
-                    int creststoremoveATK = _AttackBonusCrest + Attacker.AttackCost;
+                    int creststoremoveATK = _AttackBonusCrest;
                     int creststoremoveDEF = _DefenseBonusCrest + Defender.DefenseCost;
                     if (!_DefenderDefended) { creststoremoveDEF = 0; }
                     PlayerData AttackerPlayerData = TURNPLAYERDATA;
                     PlayerData DefenderPlayerData = OPPONENTPLAYERDATA;
                     PlayerColor AttackerColor = TURNPLAYER;
-                    PlayerColor DefenderColor = OPPONENTPLAYER;                   
-                    AdjustPlayerCrestCount(AttackerColor, Crest.ATK, -creststoremoveATK);
-                    AdjustPlayerCrestCount(DefenderColor, Crest.DEF, -creststoremoveDEF);
+                    PlayerColor DefenderColor = OPPONENTPLAYER;
+                    if (creststoremoveATK >= 1) { AdjustPlayerCrestCount(AttackerColor, Crest.ATK, -creststoremoveATK); }
+                    if (creststoremoveDEF >= 1) { AdjustPlayerCrestCount(DefenderColor, Crest.DEF, -creststoremoveDEF); }                    
 
                     //Step 5: Perform the calculation
                     int Damage = FinalAttack - FinalDefense;
@@ -1969,11 +1969,7 @@ namespace DungeonDiceMonsters
                     //Step 3: Final Defense is always 0
                     int FinalDefense = 0;
 
-                    //Step 4: Reduce the [ATK] from the attacker. Defender always "Passes"
-                    Card Attacker = _AttackerTile.CardInPlace;
-                    AdjustPlayerCrestCount(TURNPLAYER, Crest.ATK, -Attacker.AttackCost);
-
-                    //Step 5: Perform the calculation
+                    //Step 4: Perform the calculation
                     int Damage = FinalAttack - FinalDefense;
                     if (Damage <= 0)
                     {
@@ -1991,10 +1987,10 @@ namespace DungeonDiceMonsters
                     }
                     else
                     {
-                        //Step 5A: Show the final Damange Amount on the UI
+                        //Step 4A: Show the final Damange Amount on the UI
                         lblBattleMenuDamage.Text = string.Format("Damage: {0}", Damage);
 
-                        //Step 6D: if there is damage deal it to the player's symbol
+                        //Step 5D: if there is damage deal it to the player's symbol
                         if (Damage > 0)
                         {
                             //Stablish the Defender Symbol
@@ -2040,12 +2036,7 @@ namespace DungeonDiceMonsters
                 }
                 else
                 {
-                    //Destroy the defender card automatically
-                    
-                    //Reduce the [ATK] from the attacker. Defender always "Passes"
-                    Card Attacker = _AttackerTile.CardInPlace;
-                    AdjustPlayerCrestCount(TURNPLAYER, Crest.ATK, -Attacker.AttackCost);
-
+                    //Destroy the defender card automatically                   
                     SoundServer.PlaySoundEffect(SoundEffect.CardDestroyed);
                     PicDefenderDestroyed.Visible = true;
                     lblBattleMenuDamage.Text = "Damage: 0";

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
@@ -413,6 +413,9 @@ namespace DungeonDiceMonsters
                 //Remove an Attack Available Counter from this card
                 _AttackerTile.CardInPlace.RemoveAttackCounter();
 
+                //Reduce the [ATK] used based on the attack cost of the attacker
+                AdjustPlayerCrestCount(TURNPLAYER, Crest.ATK, -_AttackerTile.CardInPlace.AttackCost);
+
                 //Attack the card in this tile
                 _AttackTarger = _Tiles[tileId];
 
@@ -507,7 +510,7 @@ namespace DungeonDiceMonsters
                     _AttackBonusCrest = 0;
                     lblAttackerBonus.Text = "Bonus: 0";
                     PlayerData AttackerData = TURNPLAYERDATA;
-                    lblAttackerCrestCount.Text = string.Format("[ATK] to use: {0}/{1}", (Attacker.AttackCost + _AttackBonusCrest), AttackerData.Crests_ATK);
+                    lblAttackerCrestCount.Text = string.Format("[ATK] to use: {0}/{1}", (_AttackBonusCrest), AttackerData.Crests_ATK);
                     PanelAttackControls.Visible = true;
 
                     //If attacker monster has an advantage, enable the adv subpanel
@@ -547,7 +550,7 @@ namespace DungeonDiceMonsters
                         lblDefenderBonus.Text = "Bonus: 0";
                         PlayerData DefenderData = OPPONENTPLAYERDATA;
                         if (DefenderData.Crests_DEF == 0) { lblDefenderCrestCount.Text = "[DEF] to use: 0/0"; }
-                        else { lblDefenderCrestCount.Text = string.Format("[DEF] to use: {0}/{1}", (Defender.DefenseCost + _DefenseBonusCrest), DefenderData.Crests_DEF); }
+                        else { lblDefenderCrestCount.Text = string.Format("[DEF] to use: {0}/{1}", (_DefenseBonusCrest + Defender.DefenseCost), DefenderData.Crests_DEF); }
                         PanelDefendControls.Visible = true;
                         //If the defender does not have enought [DEF] to defend. Hide the "Defend" button
                         if (Defender.DefenseCost > DefenderData.Crests_DEF)


### PR DESCRIPTION
Now when a player declares an attack (Selects a target attack) the [ATK] used will be immediately reduced for the player's crest pool. The defender's [DEF] used will be reduced during damage calculation since this is when we know if that player decided to defend or not.