### PR TITLE
Spellbound targeting effect requirements reviewed/fixed

### DIFF
--- a/DungeonDiceMonsters/BoardPvP/BoardPvP.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP.cs
@@ -1507,7 +1507,7 @@ namespace DungeonDiceMonsters
                 }
                 string BottomlessTrapHole_MetsRequirements()
                 {
-                    if (thisCard.Controller != thisEffect.Owner && thisCard.ATK <= 3000 && thisCard.SecType == SecType.Normal)
+                    if (thisCard.Controller != thisEffect.Owner && thisCard.ATK <= 3000 && thisCard.SecType == SecType.Normal && !thisCard.IsUnderSpellbound)
                     {
                         return "Requirements Met";
                     }

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP_BaseEvents.cs
@@ -1141,7 +1141,8 @@ namespace DungeonDiceMonsters
                         case Effect.EffectID.ChangeOfHeart_Ignition: return OpponentHasAnyOneMonsterThatCanBeTarget();
                         case Effect.EffectID.CocoonofEvolution_Ignition: return CardHasAtLeastTurnCountersAmount(2);
                         case Effect.EffectID.CocconofUltraEvolution_Ignition: return PlayerHasOneCardNamed("Insect Queen");
-                        case Effect.EffectID.BasicInsect_Ignition: return OpponentHasOneMonsterTypeThatCanBeTarget(Type.Insect);
+                        case Effect.EffectID.EradicatingAerosol_Ignition: return EradicatingAerosolReqs(); break;
+                        case Effect.EffectID.BasicInsect_Ignition: return OpponentHasOneMonsterTypeThatCanBeTargetAndNotUnderSpellBound(Type.Insect);
                         case Effect.EffectID.Gokibore_Ignition: return ThereAreUnocuppiedTiles();
                         case Effect.EffectID.CockroachKnight_Ignition: return OpponentHasAnyOneMonsterThatCanBeTarget();
                         case Effect.EffectID.PinchHopper_Ingnition: return TurnPLayerHasAnyOneMonsterThatCanBeTarget();
@@ -1322,6 +1323,30 @@ namespace DungeonDiceMonsters
                             return "No opponent monster to target.";
                         }
                     }
+                    string OpponentHasOneMonsterTypeThatCanBeTargetAndNotUnderSpellBound(Type targetType)
+                    {
+                        //REQUIREMENT: Opponent must have any 1 monster on the board that can be target
+
+                        bool monsterFound = false;
+                        foreach (Card thisBoardCard in _CardsOnBoard)
+                        {
+                            if (!thisBoardCard.IsDiscardted && thisBoardCard.Controller == OPPONENTPLAYER &&
+                                thisBoardCard.CanBeTarget && thisBoardCard.Type == targetType && !thisBoardCard.IsUnderSpellbound)
+                            {
+                                monsterFound = true;
+                                break;
+                            }
+                        }
+
+                        if (monsterFound)
+                        {
+                            return "Requirements Met";
+                        }
+                        else
+                        {
+                            return "No opponent monster to target.";
+                        }
+                    }
                     string OpponentHasOneSecTypeThatCanBeTarget(SecType  targetSecType)
                     {
                         //REQUIREMENT: Opponent must have any 1 monster on the board that can be target
@@ -1462,6 +1487,33 @@ namespace DungeonDiceMonsters
                         else
                         {
                             return "Monster was not transformed into. Effect cant activate.";
+                        }
+                    }
+                    string EradicatingAerosolReqs()
+                    {
+                        //REQUIREMENT: 1 Normal Insect type monster with 2000 ATK or less that your opponent controls and is not under a spellbound
+
+                        bool monsterFound = false;
+                        foreach (Card thisBoardCard in _CardsOnBoard)
+                        {
+                            if (!thisBoardCard.IsDiscardted && thisBoardCard.IsAMonster && 
+                                thisBoardCard.SecType == SecType.Normal && thisBoardCard.ATK <= 2000 && !thisBoardCard.IsUnderSpellbound)
+                            {
+                                if ((thisBoardCard.Controller == OPPONENTPLAYER && thisBoardCard.CanBeTarget) || thisBoardCard.Controller == TURNPLAYER)
+                                {
+                                    monsterFound = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (monsterFound)
+                        {
+                            return "Requirements Met";
+                        }
+                        else
+                        {
+                            return "No valid targets.";
                         }
                     }
                     string AnyOneMonsterThatCanBeTarget()

--- a/DungeonDiceMonsters/BoardPvP/BoardPvP_Effects.cs
+++ b/DungeonDiceMonsters/BoardPvP/BoardPvP_Effects.cs
@@ -2454,14 +2454,14 @@ namespace DungeonDiceMonsters
         private void PerfectlyUltimateGreatMoth_OnSummonActivation(Effect thisEffect)
         {
             //ON SUMMON EFFECT will not activate if the monster was NOT Transform Summoned (Transformed into)
-            //And there is no ot insect type monsters on the board that the opponent owner controls
+            //And there is no ot insect type monsters on the board that the opponent owner controls (that is NOT spellbounded)
             bool activationRequirementsMet = false;
             _EffectTargetCandidates.Clear();
             if (thisEffect.OriginCard.WasTransformedInto)
             {
                 foreach (Card thisCard in _CardsOnBoard)
                 {
-                    if (!thisCard.IsDiscardted && thisCard.Type == Type.Insect && thisCard.Controller != thisEffect.Owner && thisCard.CanBeTarget)
+                    if (!thisCard.IsDiscardted && thisCard.Type == Type.Insect && thisCard.Controller != thisEffect.Owner && thisCard.CanBeTarget && !thisCard.IsUnderSpellbound)
                     {
                         activationRequirementsMet = true;
                         _EffectTargetCandidates.Add(thisCard.CurrentTile);
@@ -2915,7 +2915,7 @@ namespace DungeonDiceMonsters
             _EffectTargetCandidates.Clear();
             foreach (Card thisCard in _CardsOnBoard)
             {
-                if (!thisCard.IsDiscardted && thisCard.Controller != thisEffect.Owner && thisCard.Type == Type.Insect && thisCard.CanBeTarget)
+                if (!thisCard.IsDiscardted && thisCard.Controller != thisEffect.Owner && thisCard.Type == Type.Insect && thisCard.CanBeTarget && !thisCard.IsUnderSpellbound)
                 {
                     _EffectTargetCandidates.Add(thisCard.CurrentTile);
                 }
@@ -4363,7 +4363,8 @@ namespace DungeonDiceMonsters
             _EffectTargetCandidates.Clear();
             foreach (Card thisCard in _CardsOnBoard)
             {
-                if (!thisCard.IsDiscardted && thisCard.Type == Type.Insect && thisCard.Controller != thisEffect.Owner && thisCard.CanBeTarget)
+                if (!thisCard.IsDiscardted && thisCard.Type == Type.Insect && thisCard.Controller != thisEffect.Owner 
+                    && thisCard.CanBeTarget && !thisCard.IsUnderSpellbound)
                 {
                     _EffectTargetCandidates.Add(thisCard.CurrentTile);
                 }


### PR DESCRIPTION
List of cards reviewed:
-Trap Hole						[CLEAR]
-Acid Trap Hole					[CLEAR]
-Bottomless Trap Hole				[FIXED]
-Banishing Trap Hole				[CLEAR]
-Perfectly Ultimate Great Moth		[FIXED]
-Basic Insect						[FIXED]
-Eradicating Aerosol				[FIXED]